### PR TITLE
Make dark scroll bar in dark theme for Chromium-based browsers

### DIFF
--- a/components/GlobalStyle.ts
+++ b/components/GlobalStyle.ts
@@ -31,6 +31,8 @@ const GlobalStyle = createGlobalStyle`${css`
 
   @media (prefers-color-scheme: dark) {
     :root {
+      color-scheme: dark;
+      
       --color-background-hsl: 217 20% 8%;
       --color-circle: hsl(217deg 40% 5%);
       --color-text: hsl(217deg 20% 85%);


### PR DESCRIPTION
Make dark scroll bar in dark theme for Chromium-based browsers (show scrollbar must be enabled "Always" in system settings).