### PR TITLE
Add custom domains for go and schema workers

### DIFF
--- a/apps/go/wrangler.jsonc
+++ b/apps/go/wrangler.jsonc
@@ -3,6 +3,13 @@
   "name": "linearmouse-go",
   "compatibility_date": "2026-03-21",
   "main": "./src/index.ts",
+  "routes": [
+    {
+      "pattern": "go.linearmouse.app",
+      "custom_domain": true
+    }
+  ],
+  "preview_urls": true,
   "observability": {
     "enabled": true
   },

--- a/apps/schema/wrangler.jsonc
+++ b/apps/schema/wrangler.jsonc
@@ -3,6 +3,13 @@
   "name": "linearmouse-schema",
   "compatibility_date": "2026-03-21",
   "main": "./src/index.ts",
+  "routes": [
+    {
+      "pattern": "schema.linearmouse.app",
+      "custom_domain": true
+    }
+  ],
+  "preview_urls": true,
   "observability": {
     "enabled": true
   },


### PR DESCRIPTION
## Summary
- add production custom domain routes for `go.linearmouse.app` and `schema.linearmouse.app`
- enable preview URLs for both API workers so branch deployments can be verified before merge
- validate the updated Wrangler configs by rebuilding and deploying both workers