### PR TITLE
Add pointer speed limitations short link

### DIFF
--- a/apps/go/src/index.test.ts
+++ b/apps/go/src/index.test.ts
@@ -25,6 +25,13 @@ describe('linearmouse-go worker', () => {
     expect(response.headers.get('location')).toBe('https://github.com/linearmouse/linearmouse')
   })
 
+  it('redirects pointer speed limitations to the issue', async () => {
+    const response = await app.request('https://go.linearmouse.app/pointer-speed-limitations')
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('https://github.com/linearmouse/linearmouse/issues/270')
+  })
+
   it('returns method not allowed for non-get methods', async () => {
     const response = await app.request('https://go.linearmouse.app/github', {
       method: 'HEAD',

--- a/apps/go/src/index.ts
+++ b/apps/go/src/index.ts
@@ -5,6 +5,7 @@ const urlMap = new Map<string, string>([
   ['/github', 'https://github.com/linearmouse/linearmouse'],
   ['/accessibility-permission', 'https://github.com/linearmouse/linearmouse/blob/main/ACCESSIBILITY.md'],
   ['/disable-pointer-acceleration-and-speed', 'https://github.com/linearmouse/linearmouse/discussions/201'],
+  ['/pointer-speed-limitations', 'https://github.com/linearmouse/linearmouse/issues/270'],
   ['/bug-report', 'https://github.com/linearmouse/linearmouse/issues/new?template=bug_report.yml&labels=bug'],
   ['/feature-request', 'https://github.com/linearmouse/linearmouse/issues/new?template=feature_request.yml&labels=enhancement'],
   ['/donate', 'https://github.com/sponsors/linearmouse'],


### PR DESCRIPTION
## Summary
- add a `go.linearmouse.app/pointer-speed-limitations` redirect to the related GitHub issue
- cover the new short link with a worker redirect test