### PR TITLE
Use JSON import for locale settings

### DIFF
--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -1,5 +1,3 @@
-import { createRequire } from 'node:module'
-
 import { paraglideVitePlugin } from '@inlang/paraglide-js'
 import { defineConfig } from 'vite'
 import { devtools } from '@tanstack/devtools-vite'
@@ -9,9 +7,9 @@ import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 import viteReact from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { cloudflare } from '@cloudflare/vite-plugin'
+import projectSettingsJson from './project.inlang/settings.json'
 
-const require = createRequire(import.meta.url)
-const projectSettings = require('./project.inlang/settings.json') as {
+const projectSettings = projectSettingsJson as {
   locales: readonly string[]
 }
 


### PR DESCRIPTION
## Summary
- import the inlang project settings JSON directly in the Vite config
- remove the Node createRequire bridge from the ESM config file

## Testing
- pnpm build:website
- Playwright e2e: switch from /zh-CN/ to Bahasa Indonesia via the language menu and verify /id-ID/ with html lang=id-ID
