### PR TITLE
Type JSON locale settings import

### DIFF
--- a/apps/website/vite.config.ts
+++ b/apps/website/vite.config.ts
@@ -7,11 +7,7 @@ import { tanstackStart } from '@tanstack/react-start/plugin/vite'
 import viteReact from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { cloudflare } from '@cloudflare/vite-plugin'
-import projectSettingsJson from './project.inlang/settings.json'
-
-const projectSettings = projectSettingsJson as {
-  locales: readonly string[]
-}
+import projectSettings from './project.inlang/settings.json' with { type: 'json' }
 
 const localeRootPatterns = projectSettings.locales.map(
   (locale) => [locale, `/${locale}/`] satisfies [string, string],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -6,6 +6,7 @@
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
     "noEmit": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- import the inlang project settings JSON with an explicit JSON import attribute
- enable TypeScript JSON module typing so the Vite config no longer needs a manual type assertion

## Testing
- pnpm build:website
- Playwright e2e: switch from /zh-CN/ to Bahasa Indonesia via the language menu and verify /id-ID/ with html lang=id-ID
